### PR TITLE
Fix dynamic styles placeholder replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@ const loopWhile = require("deasync").loopWhile;
 module.exports = (css, settings) => {
     const cssWithPlaceholders = css
         .replace(
-            /\:\s*%%styled-jsx-expression-(\d+)%%/g,
-            (_, id) => `: styled-jsx-expression-${id}()`
+            /\:\s*%%styled-jsx-placeholder-(\d+)%%/g,
+            (_, id) => `: styled-jsx-placeholder-${id}()`
         )
         .replace(
-            /%%styled-jsx-expression-(\d+)%%/g,
-            (_, id) => `/*%%styled-jsx-expression-${id}%%*/`
+            /%%styled-jsx-placeholder-(\d+)%%/g,
+            (_, id) => `/*%%styled-jsx-placeholder-${id}%%*/`
         );
 
     let wait = true;
@@ -31,11 +31,11 @@ module.exports = (css, settings) => {
 
     return preprocessed
         .replace(
-            /\:\s*styled-jsx-expression-(\d+)\(\)/g,
-            (_, id) => `: %%styled-jsx-expression-${id}%%`
+            /\:\s*styled-jsx-placeholder-(\d+)\(\)/g,
+            (_, id) => `: %%styled-jsx-placeholder-${id}%%`
         )
         .replace(
-            /\/\*%%styled-jsx-expression-(\d+)%%\*\//g,
-            (_, id) => `%%styled-jsx-expression-${id}%%`
+            /\/\*%%styled-jsx-placeholder-(\d+)%%\*\//g,
+            (_, id) => `%%styled-jsx-placeholder-${id}%%`
         );
 };

--- a/test.js
+++ b/test.js
@@ -21,15 +21,15 @@ describe('styled-jsx-plugin-less', () => {
 
   it('works with expressions placeholders', () => {
     assert.equal(
-      plugin('p { img { display: block } color: %%styled-jsx-expression-1%%; } %%styled-jsx-expression-1%%').trim(),
+      plugin('p { img { display: block } color: %%styled-jsx-placeholder-1%%; } %%styled-jsx-placeholder-1%%').trim(),
       cleanup(`
         p {
-          color: %%styled-jsx-expression-1%%;
+          color: %%styled-jsx-placeholder-1%%;
         }
         p img {
           display: block;
         }
-        %%styled-jsx-expression-1%%
+        %%styled-jsx-placeholder-1%%
       `)
     )
   })


### PR DESCRIPTION
expression -> placeholder

refs: https://github.com/zeit/styled-jsx/blob/master/src/_utils.js#L250-L261


Hello, I've tried to use styled-jsx with your less plugin and interpolated dynamic styles via React component props and got this error:
```
{ [Error: Invalid % without number]
  message: 'Invalid % without number',
  stack: undefined,
  type: 'Syntax',
  filename: 'input',
  index: 716,
  line: 31,
  column: 8,
  callLine: NaN,
  callExtract: undefined,
  extract:
   [ '        margin-right: auto;',
     '        background-color: %%styled-jsx-placeholder-0%%;',
     '        padding: 8px 16px;' ] }

```

Looks like placeholder expression were changed in https://github.com/zeit/styled-jsx/commit/52c9c1ee6dff8b76c72694dbcb3eda248817b829